### PR TITLE
Bump JDK21 version (Jenkins tools) on all controllers to 21+35-ea-beta

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -249,12 +249,7 @@ profile::jenkinscontroller::jcasc:
       jnlp-webbuilder: jenkinsciinfra/builder:latest@sha256:a93427bf5a320d3510477930a514c8d5bd093426db73985016f25dabd9f2f69f
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
       jnlp: jenkins/inbound-agent:latest-jdk17@sha256:c979c256d735444af9bacccb1de480ee71bab708f2196901c8a8183e9e13df23
-  tools_default_versions:
-    jdk8: 8u382-b05
-    jdk11: 11.0.20+8
-    jdk17: 17.0.8+7
-    jdk19: 19.0.2+7
-    maven: 3.9.4
+  tools_default_versions: 21+35-ea-beta
   artifact_caching_proxy:
     providers:
       aws:


### PR DESCRIPTION



<Actions>
    <action id="af23182eef2a687f6f36ed9876aafc4e449085ca983e53fb979c4f44742bc8eb">
        <h3>Bump JDK21 version (Jenkins tools) on all controllers</h3>
        <details id="ec18bf2ad9ad29a4c8671c24fda3df5ebe23e7eb004de94e05fbc49f3e96ce3b">
            <summary>Bump JDK21 version on tools</summary>
            <p>key &#34;$..tools_default_versions.jdk21&#34; updated from &#34;                  - jdk8: 8u382-b05\n                    jdk11: 11.0.20+8\n                    jdk17: 17.0.8+7\n                    jdk19: 19.0.2+7\n                    maven: 3.9.4&#34; to &#34;21+35-ea-beta&#34;, in file &#34;hieradata/common.yaml&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

